### PR TITLE
Workaround for jgitflow 'Algorithm negotiation fail'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
                     <keepBranch>false</keepBranch>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.jcraft</groupId>
+                        <artifactId>jsch</artifactId>
+                        <version>0.1.54</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Atlassians plugin is using a deprecated algorithm when talking SSH to GitHub. This is just a workaround and should be moved to the amashchenko version.

https://ecosystem.atlassian.net/browse/MJF-299