### PR TITLE
Feature/spl 8184 activemq healthcheck

### DIFF
--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
@@ -63,14 +63,20 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
         objectMapper = environment.getObjectMapper();
 
         environment.lifecycle().manage(this);
+        registerHealCheckIfRequired(activeMQConfig, environment);
 
-        // Must use realConnectionFactory instead of (pooled) connectionFactory for the healthCheck
-        // Is needs its own connection since it is both sending and receiving.
-        // If using pool, then it might block since no one is available..
-        environment.healthChecks().register(healthCheckName,
-            new ActiveMQHealthCheck(realConnectionFactory, activeMQConfig.healthCheckMillisecondsToWait)
-        );
         this.shutdownWaitInSeconds = activeMQConfig.shutdownWaitInSeconds;
+    }
+
+    private void registerHealCheckIfRequired(ActiveMQConfig activeMQConfig, Environment environment) {
+        if (activeMQConfig.healthcheckRequired) {
+            // Must use realConnectionFactory instead of (pooled) connectionFactory for the healthCheck
+            // Is needs its own connection since it is both sending and receiving.
+            // If using pool, then it might block since no one is available..
+            environment.healthChecks().register(healthCheckName,
+                new ActiveMQHealthCheck(realConnectionFactory, activeMQConfig.healthCheckMillisecondsToWait)
+            );
+        }
     }
 
     private void configurePool(ActiveMQPoolConfig poolConfig) {

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
@@ -21,6 +21,9 @@ public class ActiveMQConfig {
     public long healthCheckMillisecondsToWait = 2000; // 2 seconds
 
     @JsonProperty
+    public boolean healthcheckRequired = true; //can be turned off by application using bundle
+
+    @JsonProperty
     public int shutdownWaitInSeconds = 20;
 
     @JsonProperty


### PR DESCRIPTION
Adding requireHealthcheck configuration parameter. 
This would allow applications, not requiring activeMQ for their core functionality, to disable activeMQ healthcheck.
The default value for requireHealthcheck-parameter is true. 

Failed to come up with an approach to test the change within bundle. Any suggestions? 