### PR TITLE
Feature/spl 8270 limit reattempts on healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,15 @@ activeMQ:
 
 activeMQ:
   brokerUrl: failover:(tcp://broker1.com:61616,tcp://broker2.com:61616)?randomize=false
+  # healthCheckAppendToBrokerUrl: &startupMaxReconnectAttempts=1 (use if healthcheck is on. Fixes hanging behavior of healthchecks when activeMQ is down. 
+    #(? or & depends on whether brokerUrl already included options))
   # brokerUsername: username
   # brokerPassword: password
   # shutdownWaitInSeconds: 20
   # healthCheckMillisecondsToWait: 2000
+  # healthCheckRequired: false (if activeMQ outage is handled well in your service and activeMQ being unavailable should NOT mark service unhealthy. Default true)
   # timeToLiveInSeconds: -1     (Default message time-to-live is off. Specify a maximum lifespan here in seconds for all messages.)
+  
   pool:
     maxConnections: 1
     maximumActiveSessionPerConnection: 3

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
@@ -80,6 +80,7 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
                 : activeMQConfig.brokerUrl;
             ActiveMQConnectionFactory healthCheckActiveMQConnectionFactory = getActiveMQConnectionFactory(healthCheckBrokerUrl, activeMQConfig.brokerUsername, activeMQConfig.brokerPassword);
             // Must use independent connectionFactory instead of (pooled) connectionFactory for the healthCheck
+            // It needs its own connection since it is both sending and receiving.
             // If using pool, then it might be blocked when pool is short on idle threads and no connection is available..
             environment.healthChecks().register(healthCheckName,
                 new ActiveMQHealthCheck(healthCheckActiveMQConnectionFactory, activeMQConfig.healthCheckMillisecondsToWait)

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
@@ -11,6 +11,11 @@ public class ActiveMQConfig {
     @NotNull
     public String brokerUrl;
 
+    /**
+     * Ex. &startupMaxReconnectAttempts=1 (use if healthcheck is on. Fixes hanging behavior of healthchecks when activeMQ is down).
+     *       ? or & depends on whether brokerUrl already included options
+     *
+     */
     @JsonProperty
     public String healthCheckAppendToBrokerUrl;
 
@@ -23,6 +28,9 @@ public class ActiveMQConfig {
     @JsonProperty
     public long healthCheckMillisecondsToWait = 2000; // 2 seconds
 
+    /**
+     * Set to false if activeMQ outage is handled well in your service and activeMQ being unavailable should NOT mark service unhealthy.
+     */
     @JsonProperty
     public boolean healthCheckRequired = true; //can be turned off by application using bundle
 

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
@@ -12,6 +12,9 @@ public class ActiveMQConfig {
     public String brokerUrl;
 
     @JsonProperty
+    public String healthCheckAppendToBrokerUrl;
+
+    @JsonProperty
     public String brokerUsername;
 
     @JsonProperty
@@ -21,7 +24,7 @@ public class ActiveMQConfig {
     public long healthCheckMillisecondsToWait = 2000; // 2 seconds
 
     @JsonProperty
-    public boolean healthcheckRequired = true; //can be turned off by application using bundle
+    public boolean healthCheckRequired = true; //can be turned off by application using bundle
 
     @JsonProperty
     public int shutdownWaitInSeconds = 20;
@@ -37,7 +40,9 @@ public class ActiveMQConfig {
     public String toString() {
         return "ActiveMQConfig{" +
                 "brokerUrl='" + brokerUrl + '\'' +
+                ", healthCheckAppendToBrokerUrl=" + healthCheckAppendToBrokerUrl +
                 ", healthCheckMillisecondsToWait=" + healthCheckMillisecondsToWait +
+                ", healthCheckRequired=" + healthCheckRequired +
                 ", shutdownWaitInSeconds=" + shutdownWaitInSeconds +
                 ", timeToLiveInSeconds=" + timeToLiveInSeconds +
                 ", brokerUsername=" + brokerUsername +


### PR DESCRIPTION
Fixing the hanging behaviour on healthchecks and (hopefully) spamming activeMQ on the way up. 
The latter is harder to verify. 